### PR TITLE
Direct HISAT2 paired-end FIFOs to task workdir tmp

### DIFF
--- a/modules/nf-core/hisat2/align/main.nf
+++ b/modules/nf-core/hisat2/align/main.nf
@@ -63,6 +63,7 @@ process HISAT2_ALIGN {
         def unaligned = params.save_unaligned ? "--un-conc-gz ${prefix}.unmapped.fastq.gz" : ''
         """
         INDEX=`find -L ./ -name "*.1.ht2" | sed 's/\\.1.ht2\$//'`
+        mkdir ./tmp
         hisat2 \\
             -x \$INDEX \\
             -1 ${reads[0]} \\
@@ -74,6 +75,7 @@ process HISAT2_ALIGN {
             --threads $task.cpus \\
             $seq_center \\
             $unaligned \\
+            --temp-directory ./tmp \\
             $args
         samtools view -bS -F 256 tmp.sam > ${prefix}.bam
         rm tmp.sam


### PR DESCRIPTION
## Problem

`HISAT2_ALIGN` fails on paired-end input with:

```
(ERR): mkfifo(/tmp/19.inpipe1) failed.
Exiting now ...
```

hisat2 creates named-pipe FIFOs when reading gzipped input and places them in its `--temp-directory`, defaulting to `/tmp` when the flag is absent. The paired-end branch never set `--temp-directory`, so FIFOs landed in `/tmp` — which fails on shared/restricted execution environments.

## Fix

Mirror the single-end branch in the paired-end branch:
- `mkdir ./tmp`
- pass `--temp-directory ./tmp` to `hisat2`

FIFOs now land in the task work directory instead of `/tmp`.

## Note

Both branches now carry the same `mkdir ./tmp` + `--temp-directory ./tmp` boilerplate. Worth consolidating into a shared command string later to prevent the two from drifting apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)